### PR TITLE
Implemented utimens in fuse to hide errors.

### DIFF
--- a/afsfuse.c
+++ b/afsfuse.c
@@ -124,6 +124,12 @@ static int afs_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_
 }
 
 
+/* utimens */
+static int afs_utimens(const char *path, const struct timespec ts[2]) {
+    return 0;
+}
+
+
 /* Destroy */
 static void afs_destroy(void *v) { saveState(); }
 
@@ -137,5 +143,6 @@ static struct fuse_operations afs_oper = {
     .create   = afs_create,
     .rename   = afs_rename,
     .unlink   = afs_unlink,
+    .utimens  = afs_utimens,
     .destroy  = afs_destroy,
 };


### PR DESCRIPTION
I added an implementation for utimens so that when touching files it doesn't throw a nasty error message. It doesn't actually write out the time, so it can still be done later if desired.
